### PR TITLE
fix: ワールドアップロード時のハッシュ重複スキップを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/cli",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "XRift CLI tool for world and avatar uploads",
   "type": "module",
   "main": "dist/index.js",

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -26,8 +26,6 @@ import type {
   UploadUrlsResponse,
   CompleteUploadRequest,
   CompleteUploadResponse,
-  UpdateWorldVersionMetadataRequest,
-  UpdateWorldVersionMetadataResponse,
 } from '../types/index.js';
 
 /**
@@ -225,75 +223,7 @@ export async function uploadWorld(cwd: string = process.cwd(), skipCheck?: boole
       signedUrls = response.data.uploadUrls;
       versionId = response.data.versionId;
       versionNumber = response.data.versionNumber;
-      const alreadyExists = response.data.alreadyExists || false;
 
-      if (alreadyExists) {
-        // 既存バージョンの場合：メタデータのみ更新
-        spinner.succeed(chalk.yellow(`A version with the same content already exists (v${versionNumber})`));
-        console.log(chalk.yellow('📦 File upload skipped'));
-
-        // WorldVersionのメタデータを更新
-        if (worldConfig.title || worldConfig.description || thumbnailPath !== undefined || worldConfig.physics || worldConfig.camera) {
-          spinner = ora('Updating world info...').start();
-          try {
-            const updateRequest: UpdateWorldVersionMetadataRequest = {};
-            if (worldConfig.title) {
-              updateRequest.name = worldConfig.title;
-            }
-            if (worldConfig.description !== undefined) {
-              updateRequest.description = worldConfig.description;
-            }
-            if (thumbnailPath !== undefined) {
-              updateRequest.thumbnailPath = thumbnailPath;
-            }
-            if (worldConfig.physics) {
-              updateRequest.physics = worldConfig.physics;
-            }
-            if (worldConfig.camera) {
-              updateRequest.camera = worldConfig.camera;
-            }
-
-            const updateUrl = `${WORLD_UPDATE_PATH}/${worldId}/versions/${versionId}`;
-            logVerbose(`PATCH ${updateUrl}`);
-            logVerbose(`Request body: ${JSON.stringify(updateRequest, null, 2)}`);
-
-            const updateResponse = await client.patch<UpdateWorldVersionMetadataResponse>(
-              updateUrl,
-              updateRequest
-            );
-
-            spinner.succeed(chalk.green('✓ World info updated'));
-            console.log(chalk.gray(`  Title: ${updateResponse.data.name}`));
-            if (updateResponse.data.description) {
-              console.log(chalk.gray(`  Description: ${updateResponse.data.description}`));
-            }
-            if (updateResponse.data.thumbnailPath) {
-              console.log(chalk.gray(`  Thumbnail: ${updateResponse.data.thumbnailPath}`));
-            }
-
-            console.log(chalk.green('\n✅ Done'));
-            return; // 正常終了
-          } catch (updateError) {
-            spinner.fail(chalk.red('Failed to update world info'));
-            if (axios.isAxiosError(updateError)) {
-              if (updateError.response) {
-                console.error(chalk.red(`Status code: ${updateError.response.status}`));
-                console.error(chalk.red(`Error details: ${JSON.stringify(updateError.response.data, null, 2)}`));
-              } else if (updateError.request) {
-                console.error(chalk.red('Request was sent but no response was received'));
-              } else {
-                console.error(chalk.red(`Error: ${updateError.message}`));
-              }
-            }
-            throw updateError;
-          }
-        } else {
-          console.log(chalk.yellow('No information to update'));
-          return; // 何もせず終了
-        }
-      }
-
-      // 新規バージョンの場合：通常のアップロードフロー
       spinner.succeed(
         chalk.green(
           `Retrieved ${signedUrls.length} upload URLs (version: ${versionNumber})`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -100,7 +100,6 @@ export interface UploadUrlsResponse {
   versionId: string;
   contentHash: string;
   versionNumber: number;
-  alreadyExists?: boolean; // 既存バージョンの場合true
 }
 
 export interface CompleteUploadRequest {
@@ -129,26 +128,6 @@ export interface UpdateWorldMetadataRequest {
   description?: string;
 }
 
-export interface UpdateWorldVersionMetadataRequest {
-  name?: string;
-  description?: string | null;
-  thumbnailPath?: string | null;
-  physics?: PhysicsConfig | null; // 物理設定更新（nullで削除）
-  camera?: CameraConfig | null; // カメラ設定更新（nullで削除）
-}
-
-export interface UpdateWorldVersionMetadataResponse {
-  id: string;
-  worldId: string;
-  name: string;
-  description?: string;
-  thumbnailPath?: string;
-  contentHash: string;
-  fileSize: string;
-  status: string;
-  versionNumber: number;
-  updatedAt: string;
-}
 
 export interface VerifyTokenResponse {
   valid: boolean;


### PR DESCRIPTION
## Summary
- ワールドアップロード時に前回と同じビルドハッシュの場合にスキップする処理を削除
- 毎回アップロードが実行されるように変更（ユーザーがアップロードしたと思ったのに反映されない問題を解消）
- 不要になった `alreadyExists` フィールドと関連型定義を削除
- バージョンを 0.19.1 に更新

## Test plan
- [x] TypeScript 型チェック通過
- [x] 全テスト通過（58 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)