### PR TITLE
feat: create コマンドに Item 選択肢を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/cli",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "XRift CLI tool for world and avatar uploads",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import prompts from 'prompts';
 import { createWorld } from '../lib/create-world.js';
+import { createItem } from '../lib/create-item.js';
 
 export const createCommand = new Command('create')
   .description('Create a new XRift project')
@@ -13,7 +14,7 @@ export const createCommand = new Command('create')
       message: 'What would you like to create?',
       choices: [
         { title: 'World', value: 'world' },
-        // 将来: { title: 'Item', value: 'item' },
+        { title: 'Item', value: 'item' },
       ],
     });
 
@@ -22,17 +23,19 @@ export const createCommand = new Command('create')
       process.exit(0);
     }
 
-    if (response.type === 'world') {
-      try {
+    try {
+      if (response.type === 'world') {
         await createWorld(undefined, {});
-      } catch (error) {
-        if (error instanceof Error) {
-          console.error(chalk.red('\nError:'), error.message);
-        } else {
-          console.error(chalk.red('\nAn unexpected error occurred'));
-        }
-        process.exit(1);
+      } else if (response.type === 'item') {
+        await createItem(undefined, {});
       }
+    } catch (error) {
+      if (error instanceof Error) {
+        console.error(chalk.red('\nError:'), error.message);
+      } else {
+        console.error(chalk.red('\nAn unexpected error occurred'));
+      }
+      process.exit(1);
     }
   });
 
@@ -51,6 +54,31 @@ createCommand
   .action(async (projectName: string | undefined, options) => {
     try {
       await createWorld(projectName, options);
+    } catch (error) {
+      if (error instanceof Error) {
+        console.error(chalk.red('\nError:'), error.message);
+      } else {
+        console.error(chalk.red('\nAn unexpected error occurred'));
+      }
+      process.exit(1);
+    }
+  });
+
+createCommand
+  .command('item')
+  .argument('[project-name]', 'Project name (interactive if omitted)')
+  .option(
+    '-t, --template <repository>',
+    'Template repository (e.g. WebXR-JP/xrift-item-template)',
+    'WebXR-JP/xrift-item-template'
+  )
+  .option('--skip-install', 'Skip dependency installation')
+  .option('--here', 'Create directly in the current directory')
+  .option('-y, --no-interactive', 'Disable interactive mode')
+  .description('Create a new XRift item project')
+  .action(async (projectName: string | undefined, options) => {
+    try {
+      await createItem(projectName, options);
     } catch (error) {
       if (error instanceof Error) {
         console.error(chalk.red('\nError:'), error.message);

--- a/src/lib/create-item.ts
+++ b/src/lib/create-item.ts
@@ -1,0 +1,251 @@
+import { resolve } from 'path';
+import { access, constants, readdir } from 'fs';
+import chalk from 'chalk';
+import prompts from 'prompts';
+import {
+  downloadTemplate,
+  customizeItemProject,
+  installDependencies,
+} from './template.js';
+
+/**
+ * ファイルまたはディレクトリが存在するかチェック
+ */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await new Promise<void>((resolve, reject) => {
+      access(path, constants.F_OK, (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * ディレクトリが空かチェック
+ */
+async function isDirectoryEmpty(path: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    readdir(path, (err, files) => {
+      if (err) {
+        reject(err);
+      } else {
+        const visibleFiles = files.filter((file) => !file.startsWith('.'));
+        resolve(visibleFiles.length === 0);
+      }
+    });
+  });
+}
+
+export interface CreateItemOptions {
+  template?: string;
+  skipInstall?: boolean;
+  here?: boolean;
+  interactive?: boolean;
+  y?: boolean;
+}
+
+export async function createItem(
+  projectName: string | undefined,
+  options: CreateItemOptions
+): Promise<void> {
+  // テンプレートのデフォルト値
+  if (!options.template) {
+    options.template = 'WebXR-JP/xrift-item-template';
+  }
+
+  // --no-interactive の場合、プロジェクト名が必須
+  if (options.interactive === false && !projectName) {
+    throw new Error('Project name is required when using --no-interactive');
+  }
+
+  // 対話式モードが必要か判定
+  const needsInteraction =
+    options.interactive !== false &&
+    (!projectName ||
+      options.here === undefined ||
+      options.skipInstall === undefined);
+
+  let itemTitle = '';
+  let itemDescription = '';
+
+  if (needsInteraction) {
+    console.log(chalk.cyan('\n✨ Creating an XRift item\n'));
+
+    const questions = [];
+
+    // プロジェクト名が未指定の場合のみ質問
+    if (!projectName) {
+      questions.push({
+        type: 'text',
+        name: 'projectName',
+        message: 'Enter a project name',
+        validate: (value: string) =>
+          /^[a-z0-9-]+$/.test(value)
+            ? true
+            : 'Only lowercase alphanumeric characters and hyphens are allowed',
+      });
+    }
+
+    // 作成場所が未指定の場合のみ質問
+    if (options.here === undefined) {
+      questions.push({
+        type: 'select',
+        name: 'location',
+        message: 'Where should the project be created?',
+        choices: [
+          { title: 'Create a new directory', value: 'new' },
+          { title: 'Create in the current directory', value: 'here' },
+        ],
+        initial: 0,
+      });
+    }
+
+    // テンプレートがデフォルトの場合のみ質問
+    if (!options.template || options.template === 'WebXR-JP/xrift-item-template') {
+      questions.push({
+        type: 'select',
+        name: 'templateType',
+        message: 'Select a template',
+        choices: [
+          { title: 'Default (WebXR-JP/xrift-item-template)', value: 'default' },
+          { title: 'Custom template', value: 'custom' },
+        ],
+        initial: 0,
+      });
+      questions.push({
+        type: (prev: string) => (prev === 'custom' ? 'text' : null),
+        name: 'customTemplate',
+        message: 'Enter a GitHub repository (e.g. username/repo)',
+        validate: (value: string) =>
+          value && value.includes('/')
+            ? true
+            : 'Please enter a valid format (username/repo)',
+      });
+    }
+
+    // アイテムタイトル（必須）
+    questions.push({
+      type: 'text',
+      name: 'itemTitle',
+      message: 'Enter an item title',
+      validate: (value: string) =>
+        value.trim().length > 0 ? true : 'Item title is required',
+    });
+
+    // アイテムの説明（任意）
+    questions.push({
+      type: 'text',
+      name: 'itemDescription',
+      message: 'Enter an item description (optional)',
+    });
+
+    // インストール有無が未指定の場合のみ質問
+    if (options.skipInstall === undefined) {
+      questions.push({
+        type: 'confirm',
+        name: 'install',
+        message: 'Install dependencies?',
+        initial: true,
+      });
+    }
+
+    const response = await prompts(questions as any);
+
+    // ユーザーがキャンセルした場合
+    if (Object.keys(response).length === 0) {
+      console.log(chalk.yellow('\n❌ Cancelled'));
+      process.exit(0);
+    }
+
+    // 対話式モードの回答を変数に設定
+    if (response.projectName) {
+      projectName = response.projectName;
+    }
+    if (response.location !== undefined) {
+      options.here = response.location === 'here';
+    }
+    if (response.install !== undefined) {
+      options.skipInstall = !response.install;
+    }
+    if (response.templateType === 'custom') {
+      options.template = response.customTemplate;
+    }
+    itemTitle = response.itemTitle?.trim() || '';
+    itemDescription = response.itemDescription?.trim() || '';
+  }
+
+  // この時点で projectName は必ず定義されている
+  if (!projectName) {
+    throw new Error('Project name is not specified');
+  }
+
+  console.log(chalk.cyan(`\n✨ Creating an XRift item...\n`));
+
+  // プロジェクト名のバリデーション
+  if (!/^[a-z0-9-]+$/.test(projectName)) {
+    throw new Error(
+      'Project name must contain only lowercase alphanumeric characters and hyphens'
+    );
+  }
+
+  // プロジェクトパスの設定
+  let projectPath: string;
+
+  if (options.here) {
+    // カレントディレクトリに作成
+    projectPath = process.cwd();
+
+    // カレントディレクトリが空かチェック
+    const isEmpty = await isDirectoryEmpty(projectPath);
+    if (!isEmpty) {
+      console.log(
+        chalk.yellow(
+          '⚠️  The current directory is not empty. Existing files may be overwritten.'
+        )
+      );
+    }
+  } else {
+    // 新しいディレクトリを作成
+    projectPath = resolve(process.cwd(), projectName);
+
+    // 既存ディレクトリのチェック
+    const exists = await pathExists(projectPath);
+    if (exists) {
+      throw new Error(`Directory "${projectName}" already exists`);
+    }
+  }
+
+  // テンプレートのダウンロード
+  await downloadTemplate(options.template!, projectPath);
+
+  // プロジェクトのカスタマイズ
+  await customizeItemProject(
+    projectName,
+    projectPath,
+    itemTitle || projectName,
+    itemDescription
+  );
+
+  // 依存関係のインストール
+  if (!options.skipInstall) {
+    await installDependencies(projectPath);
+  }
+
+  // 完了メッセージ
+  console.log(chalk.green('\n✅ Project created successfully!\n'));
+  console.log(chalk.cyan('Next steps:'));
+  if (!options.here) {
+    console.log(`  ${chalk.yellow(`cd ${projectName}`)}`);
+  }
+  if (options.skipInstall) {
+    console.log(`  ${chalk.yellow('npm install')}       # Install dependencies`);
+  }
+  console.log(`  ${chalk.yellow('npm run dev')}        # Start dev server`);
+  console.log(`  ${chalk.yellow('npm run build')}      # Build`);
+  console.log(`  ${chalk.yellow('xrift upload item')}  # Upload to XRift\n`);
+}

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -127,6 +127,59 @@ export async function customizeProject(
 }
 
 /**
+ * アイテムプロジェクトファイルをカスタマイズする
+ */
+export async function customizeItemProject(
+  projectName: string,
+  projectPath: string,
+  itemTitle: string,
+  itemDescription: string
+): Promise<void> {
+  const spinner = ora('Customizing project...').start();
+
+  try {
+    const snakeCaseName = toSnakeCase(projectName);
+
+    // package.json を更新
+    await replaceInFile(join(projectPath, 'package.json'), [
+      { from: '@xrift/item-template', to: `@xrift/${projectName}` },
+      { from: '"version": "0.2.1"', to: '"version": "0.1.0"' },
+      { from: '"version": "1.0.0"', to: '"version": "0.1.0"' },
+    ]);
+
+    // vite.config.ts を更新
+    await replaceInFile(join(projectPath, 'vite.config.ts'), [
+      { from: 'xrift_item_template', to: `xrift_${snakeCaseName}` },
+    ]);
+
+    // index.html を更新（アイテムタイトルを使用）
+    await replaceInFile(join(projectPath, 'index.html'), [
+      { from: '<title>xrift-item-template</title>', to: `<title>${itemTitle}</title>` },
+    ]);
+
+    // xrift.json を更新（アイテムタイトル・説明を反映）
+    const xriftJsonPath = join(projectPath, 'xrift.json');
+    if (await pathExists(xriftJsonPath)) {
+      const raw = await readFile(xriftJsonPath, 'utf-8');
+      const config = JSON.parse(raw);
+      if (!config.item) {
+        config.item = {};
+      }
+      config.item.title = itemTitle;
+      if (itemDescription) {
+        config.item.description = itemDescription;
+      }
+      await writeFile(xriftJsonPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    }
+
+    spinner.succeed('Project customized');
+  } catch (error) {
+    spinner.fail('Failed to customize project');
+    throw error;
+  }
+}
+
+/**
  * 依存関係をインストールする
  */
 export async function installDependencies(projectPath: string): Promise<void> {


### PR DESCRIPTION
## Summary
- `xrift create` の対話型選択肢に Item を追加
- `xrift create item [project-name]` サブコマンドを新規登録
- `customizeItemProject` 関数で Item テンプレートのカスタマイズ（package.json, vite.config.ts, index.html, xrift.json）に対応

## Test plan
- [ ] `npx tsx src/index.ts create` → Item を選択して対話型フローが動作すること
- [ ] `npx tsx src/index.ts create item my-item` → サブコマンドで直接指定可能なこと
- [ ] `npm run build` が通ること ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)