### PR TITLE
feat: Item アップロードフローを ItemVersion ベースに移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "XRift CLI tool for world and avatar uploads",
   "type": "module",
   "main": "dist/index.js",

--- a/src/lib/item.ts
+++ b/src/lib/item.ts
@@ -20,9 +20,12 @@ import { runSecurityCheck, printResults } from './check.js';
 import type {
   CreateItemRequest,
   CreateItemResponse,
+  SignedUrlResponse,
   UploadFileInfo,
   ItemUploadUrlsRequest,
   ItemUploadUrlsResponse,
+  CompleteItemUploadRequest,
+  CompleteItemUploadResponse,
 } from '../types/index.js';
 
 /**
@@ -84,7 +87,7 @@ export async function uploadItem(cwd: string = process.cwd(), skipCheck?: boolea
       spinner = ora('Running security check...').start();
       const jsFiles = files.filter((f) => /\.(js|mjs)$/.test(f));
       if (jsFiles.length > 0) {
-        const checkResult = await runSecurityCheck(jsFiles, distDir);
+        const checkResult = await runSecurityCheck(jsFiles, distDir, itemConfig.permissions);
         if (checkResult.hasReject) {
           spinner.fail('Security check failed');
           printResults(checkResult);
@@ -98,6 +101,28 @@ export async function uploadItem(cwd: string = process.cwd(), skipCheck?: boolea
         }
       } else {
         spinner.succeed('No JS files to check');
+      }
+    }
+
+    // 3.6. サムネイル設定を確認
+    let thumbnailPath: string | undefined;
+    if (itemConfig.thumbnailPath) {
+      const configuredPath = path.join(distDir, itemConfig.thumbnailPath);
+      try {
+        const stat = await fs.stat(configuredPath);
+        if (stat.isFile()) {
+          thumbnailPath = itemConfig.thumbnailPath;
+          console.log(chalk.green(`✓ Thumbnail: ${itemConfig.thumbnailPath}`));
+        } else {
+          throw new Error(`${itemConfig.thumbnailPath} is not a file`);
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new Error(
+            `Configured thumbnail not found: ${itemConfig.thumbnailPath}`
+          );
+        }
+        throw error;
       }
     }
 
@@ -122,12 +147,18 @@ export async function uploadItem(cwd: string = process.cwd(), skipCheck?: boolea
     // 6. アイテムメタデータを確認（新規/更新判定）
     const existingMetadata = await loadItemMetadata(cwd);
     let itemId: string;
+    let itemName: string;
+    let itemDescription: string | undefined;
 
     if (existingMetadata) {
       logVerbose(`\nUpdating existing item (ID: ${existingMetadata.id})`);
       itemId = existingMetadata.id;
+
+      // 更新時は設定ファイルから名前と説明を取得
+      itemName = itemConfig.title || path.basename(cwd);
+      itemDescription = itemConfig.description;
     } else {
-      // メタデータを収集
+      // 新規作成時はメタデータを収集
       const metadata = await collectItemMetadata(
         {
           title: itemConfig.title,
@@ -135,15 +166,14 @@ export async function uploadItem(cwd: string = process.cwd(), skipCheck?: boolea
         },
         path.basename(cwd)
       );
+      itemName = metadata.title;
+      itemDescription = metadata.description;
 
-      // 新規アイテム作成
+      // 新規アイテム作成（空のリクエストボディ）
       spinner = ora('Creating new item...').start();
 
       try {
-        const createRequest: CreateItemRequest = {
-          name: metadata.title,
-          description: metadata.description,
-        };
+        const createRequest: CreateItemRequest = {};
 
         const response = await client.post<CreateItemResponse>(ITEM_CREATE_PATH, createRequest);
 
@@ -166,14 +196,21 @@ export async function uploadItem(cwd: string = process.cwd(), skipCheck?: boolea
     // 8. 署名付きURLを取得
     spinner = ora('Fetching upload URLs...').start();
 
+    let signedUrls: SignedUrlResponse[];
+    let versionId: string;
+    let versionNumber: number;
     try {
       const uploadUrlsRequest: ItemUploadUrlsRequest = {
+        name: itemName,
+        description: itemDescription,
+        thumbnailPath: thumbnailPath,
         contentHash,
         fileSize,
         files: uploadFiles.map((f) => ({
           path: f.remotePath,
           contentType: getMimeType(f.localPath),
         })),
+        permissions: itemConfig.permissions,
       };
 
       const response = await client.post<ItemUploadUrlsResponse>(
@@ -181,72 +218,97 @@ export async function uploadItem(cwd: string = process.cwd(), skipCheck?: boolea
         uploadUrlsRequest
       );
 
-      const signedUrls = response.data.uploadUrls;
+      signedUrls = response.data.uploadUrls;
+      versionId = response.data.versionId;
+      versionNumber = response.data.versionNumber;
 
       spinner.succeed(
-        chalk.green(`Retrieved ${signedUrls.length} upload URLs`)
+        chalk.green(
+          `Retrieved ${signedUrls.length} upload URLs (version: ${versionNumber})`
+        )
       );
 
       if (signedUrls.length > 0) {
         logVerbose(`Debug: First URL structure: ${JSON.stringify(signedUrls[0], null, 2)}`);
       }
-
-      // 9. ファイルをアップロード
-      console.log(chalk.blue('\n📤 Uploading files...\n'));
-
-      const progressBar = new cliProgress.SingleBar(
-        {
-          format: `${chalk.cyan('{bar}')} | {percentage}% | {value}/{total} files | {filename}`,
-          barCompleteChar: '█',
-          barIncompleteChar: '░',
-          hideCursor: true,
-        },
-        cliProgress.Presets.shades_classic
-      );
-
-      progressBar.start(uploadFiles.length, 0, { filename: '' });
-
-      for (let i = 0; i < uploadFiles.length; i++) {
-        const fileInfo = uploadFiles[i];
-        const signedUrl = signedUrls[i];
-
-        progressBar.update(i, { filename: fileInfo.remotePath });
-
-        try {
-          const fileBuffer = await fs.readFile(fileInfo.localPath);
-
-          await axios.put(signedUrl.uploadUrl, fileBuffer, {
-            headers: {
-              'Content-Type': getMimeType(fileInfo.localPath),
-              'Content-Length': fileInfo.size,
-            },
-            maxContentLength: Infinity,
-            maxBodyLength: Infinity,
-          });
-        } catch (error) {
-          progressBar.stop();
-          console.error(chalk.red(`\n❌ Failed to upload ${fileInfo.remotePath}`));
-          throw error;
-        }
-      }
-
-      progressBar.update(uploadFiles.length, { filename: 'Done' });
-      progressBar.stop();
-
-      // 10. アップロード完了通知
-      spinner = ora('Notifying upload completion...').start();
-
-      await client.post(`${ITEM_COMPLETE_PATH}/${itemId}/complete`);
-
-      spinner.succeed(chalk.green('Upload completed'));
+      logVerbose(`Version ID: ${versionId}`);
     } catch (error) {
-      spinner.fail(chalk.red('Failed during upload'));
+      spinner.fail(chalk.red('Failed to retrieve upload URLs'));
       if (axios.isAxiosError(error) && error.response) {
         const errorData = error.response.data;
         const errorMessage = typeof errorData === 'object' && errorData.error
           ? errorData.error
           : JSON.stringify(errorData);
         console.error(chalk.red(`Backend error: ${errorMessage}`));
+      }
+      throw error;
+    }
+
+    // 9. ファイルをアップロード
+    console.log(chalk.blue('\n📤 Uploading files...\n'));
+
+    const progressBar = new cliProgress.SingleBar(
+      {
+        format: `${chalk.cyan('{bar}')} | {percentage}% | {value}/{total} files | {filename}`,
+        barCompleteChar: '█',
+        barIncompleteChar: '░',
+        hideCursor: true,
+      },
+      cliProgress.Presets.shades_classic
+    );
+
+    progressBar.start(uploadFiles.length, 0, { filename: '' });
+
+    for (let i = 0; i < uploadFiles.length; i++) {
+      const fileInfo = uploadFiles[i];
+      const signedUrl = signedUrls[i];
+
+      progressBar.update(i, { filename: fileInfo.remotePath });
+
+      try {
+        const fileBuffer = await fs.readFile(fileInfo.localPath);
+
+        await axios.put(signedUrl.uploadUrl, fileBuffer, {
+          headers: {
+            'Content-Type': getMimeType(fileInfo.localPath),
+            'Content-Length': fileInfo.size,
+          },
+          maxContentLength: Infinity,
+          maxBodyLength: Infinity,
+        });
+      } catch (error) {
+        progressBar.stop();
+        console.error(chalk.red(`\n❌ Failed to upload ${fileInfo.remotePath}`));
+        throw error;
+      }
+    }
+
+    progressBar.update(uploadFiles.length, { filename: 'Done' });
+    progressBar.stop();
+
+    // 10. アップロード完了通知
+    spinner = ora('Notifying upload completion...').start();
+    try {
+      const completeRequest: CompleteItemUploadRequest = {
+        versionId,
+      };
+
+      const completeResponse = await client.post<CompleteItemUploadResponse>(
+        `${ITEM_COMPLETE_PATH}/${itemId}/complete`,
+        completeRequest
+      );
+
+      spinner.succeed(
+        chalk.green(
+          `Upload completed (version: ${completeResponse.data.versionNumber})`
+        )
+      );
+      logVerbose(`Status: ${completeResponse.data.status}`);
+      logVerbose(`Item name: ${completeResponse.data.name}`);
+    } catch (error) {
+      spinner.fail(chalk.red('Failed to notify upload completion'));
+      if (axios.isAxiosError(error) && error.response) {
+        console.error(chalk.red(`Backend error: ${JSON.stringify(error.response.data)}`));
       }
       throw error;
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,11 @@ export interface WorldPermissions {
   allowedCodeRules?: string[];
 }
 
+export interface ItemPermissions {
+  allowedDomains?: string[];
+  allowedCodeRules?: string[];
+}
+
 export interface XriftConfig {
   world?: {
     distDir: string;
@@ -36,6 +41,7 @@ export interface XriftConfig {
     thumbnailPath?: string; // サムネイルパス
     buildCommand?: string; // アップロード前に実行するビルドコマンド
     ignore?: string[]; // アップロード対象から除外するglobパターン
+    permissions?: ItemPermissions; // セキュリティ権限宣言
   };
 }
 
@@ -154,35 +160,49 @@ export interface ExchangeTokenResponse {
 // Item types
 
 export interface CreateItemRequest {
-  name: string;
-  description?: string;
+  // ItemVersion ベース: 空のリクエストボディ
 }
 
 export interface CreateItemResponse {
   id: string;
-  name: string;
-  description?: string;
   ownerId: string;
-  status: string;
   createdAt: string;
   updatedAt: string;
 }
 
 export interface ItemUploadUrlsRequest {
-  contentHash: string;
+  name: string; // アイテム名（必須）
+  description?: string; // 説明（任意）
+  thumbnailPath?: string; // サムネイルパス（任意）
+  contentHash: string; // 12文字の16進数
   fileSize: number;
   files: Array<{
     path: string;
     contentType: string;
   }>;
+  permissions?: ItemPermissions; // セキュリティ権限宣言（任意）
 }
 
 export interface ItemUploadUrlsResponse {
+  uploadUrls: SignedUrlResponse[];
+  versionId: string;
+  contentHash: string;
+  versionNumber: number;
+}
+
+export interface CompleteItemUploadRequest {
+  versionId: string;
+}
+
+export interface CompleteItemUploadResponse {
+  versionId: string;
   itemId: string;
-  uploadUrls: Array<{
-    path: string;
-    uploadUrl: string;
-    publicUrl: string;
-    expiresAt: string;
-  }>;
+  name: string;
+  description?: string;
+  contentHash: string;
+  fileSize: number;
+  status: string;
+  versionNumber: number;
+  createdAt: string;
+  updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- バックエンドの Item バージョン管理導入（PR #390〜#394）に合わせて、CLI のアイテムアップロードフローを新しい ItemVersion ベースの API に移行
- World アップロードフローと同じパターンに統一（空の作成リクエスト → upload-urls で名前・説明・権限を送信 → complete に versionId を送信）
- `ItemPermissions` 型と `xrift.json` の `item.permissions` フィールドを追加

## 変更内容
- `CreateItemRequest`: 空のリクエストボディに変更
- `ItemUploadUrlsRequest`: `name`, `description`, `thumbnailPath`, `permissions` を追加
- `ItemUploadUrlsResponse`: `versionId`, `versionNumber` を追加（`SignedUrlResponse[]` を使用）
- `CompleteItemUploadRequest/Response`: 新規追加（versionId ベース）
- サムネイル検証ロジックを追加
- セキュリティチェックに `permissions` を渡すよう変更

## Test plan
- [x] TypeScript ビルドが通ること（`tsc --noEmit`）
- [x] 既存テスト 58 件がすべてパスすること（`jest`）
- [ ] 実際のアイテムアップロードで動作確認

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)