### PR TITLE
xrift.json に title がある場合 upload 時の対話式プロンプトをスキップ

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/cli",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "XRift CLI tool for world and avatar uploads",
   "type": "module",
   "main": "dist/index.js",

--- a/src/lib/create-world.ts
+++ b/src/lib/create-world.ts
@@ -228,7 +228,7 @@ export async function createWorld(
   await customizeProject(
     projectName,
     projectPath,
-    worldTitle || projectName,
+    worldTitle,
     worldDescription
   );
 

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -98,13 +98,14 @@ export async function customizeProject(
       { from: 'xrift_world_template', to: `xrift_${snakeCaseName}` },
     ]);
 
-    // index.html を更新（ワールドタイトルを使用）
+    // index.html を更新（ワールドタイトルを使用、未指定時はプロジェクト名）
+    const htmlTitle = worldTitle || projectName;
     await replaceInFile(join(projectPath, 'index.html'), [
-      { from: '<title>XRift Test World</title>', to: `<title>${worldTitle}</title>` },
-      { from: '<title>XRift World Template</title>', to: `<title>${worldTitle}</title>` },
+      { from: '<title>XRift Test World</title>', to: `<title>${htmlTitle}</title>` },
+      { from: '<title>XRift World Template</title>', to: `<title>${htmlTitle}</title>` },
     ]);
 
-    // xrift.json を更新（ワールドタイトル・説明を反映）
+    // xrift.json を更新（ワールドタイトル・説明を反映、未入力時は書き込まない）
     const xriftJsonPath = join(projectPath, 'xrift.json');
     if (await pathExists(xriftJsonPath)) {
       const raw = await readFile(xriftJsonPath, 'utf-8');
@@ -112,7 +113,9 @@ export async function customizeProject(
       if (!config.world) {
         config.world = {};
       }
-      config.world.title = worldTitle;
+      if (worldTitle) {
+        config.world.title = worldTitle;
+      }
       if (worldDescription) {
         config.world.description = worldDescription;
       }

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -159,13 +159,23 @@ export async function uploadWorld(cwd: string = process.cwd(), skipCheck?: boole
       worldDescription = worldConfig.description;
     } else {
       // 新規作成時はメタデータを収集
-      const metadata = await collectWorldMetadata(
-        {
-          title: worldConfig.title,
-          description: worldConfig.description,
-        },
-        path.basename(cwd)
-      );
+      // xrift.json に title があればプロンプトをスキップ
+      let metadata: { title: string; description?: string };
+      if (worldConfig.title) {
+        metadata = { title: worldConfig.title, description: worldConfig.description };
+        console.log(chalk.blue(`\n📝 World title: ${metadata.title}`));
+        if (metadata.description) {
+          console.log(chalk.blue(`   Description: ${metadata.description}`));
+        }
+      } else {
+        metadata = await collectWorldMetadata(
+          {
+            title: worldConfig.title,
+            description: worldConfig.description,
+          },
+          path.basename(cwd)
+        );
+      }
       worldName = metadata.title;
       worldDescription = metadata.description;
 


### PR DESCRIPTION
## Summary
- `xrift upload world` 時、xrift.json に `title` が設定されていれば対話式プロンプト（title/description 入力）をスキップ
- `xrift create world` 時、title/description が未入力なら xrift.json に書き込まないように変更

## Test plan
- [ ] xrift.json に `title` を設定した状態で `xrift upload world` → プロンプトなしでアップロード開始
- [ ] xrift.json に `title` がない状態で `xrift upload world` → 従来通り対話式プロンプト表示
- [ ] `xrift create world` で title 未入力 → xrift.json に title が書き込まれない
- [ ] `xrift create world` で title 入力 → xrift.json に title が書き込まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)