### PR TITLE
feat: xrift.json の world 設定に outputBufferType を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/cli",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "XRift CLI tool for world and avatar uploads",
   "type": "module",
   "main": "dist/index.js",

--- a/src/lib/__tests__/project-config.test.ts
+++ b/src/lib/__tests__/project-config.test.ts
@@ -162,6 +162,41 @@ describe('project-config', () => {
       expect(loaded.world!.camera?.far).toBe(5000);
     });
 
+    it('outputBufferType設定を含む設定ファイルを読み込める', async () => {
+      const config: XriftConfig = {
+        world: {
+          distDir: './dist',
+          title: 'Test World',
+          outputBufferType: 'HalfFloatType',
+        },
+      };
+
+      await fs.writeFile(
+        path.join(testDir, 'xrift.json'),
+        JSON.stringify(config, null, 2)
+      );
+
+      const loaded = await loadProjectConfig(testDir);
+      expect(loaded).toEqual(config);
+      expect(loaded.world!.outputBufferType).toBe('HalfFloatType');
+    });
+
+    it('outputBufferTypeが未指定の場合はundefined', async () => {
+      const config: XriftConfig = {
+        world: {
+          distDir: './dist',
+        },
+      };
+
+      await fs.writeFile(
+        path.join(testDir, 'xrift.json'),
+        JSON.stringify(config, null, 2)
+      );
+
+      const loaded = await loadProjectConfig(testDir);
+      expect(loaded.world!.outputBufferType).toBeUndefined();
+    });
+
     it('physics設定が部分的に指定されている場合も読み込める', async () => {
       const config: XriftConfig = {
         world: {

--- a/src/lib/__tests__/upload.test.ts
+++ b/src/lib/__tests__/upload.test.ts
@@ -395,7 +395,7 @@ describe('upload - メタデータ更新ロジックテスト', () => {
           distDir: 'dist',
           title: undefined as string | undefined,
           description: undefined as string | undefined,
-          outputBufferType: 'FloatType' as const,
+          outputBufferType: 'UnsignedByteType' as const,
         },
       };
 
@@ -415,7 +415,7 @@ describe('upload - メタデータ更新ロジックテスト', () => {
       }
 
       expect(updateRequest).toEqual({
-        outputBufferType: 'FloatType',
+        outputBufferType: 'UnsignedByteType',
       });
     });
 

--- a/src/lib/__tests__/upload.test.ts
+++ b/src/lib/__tests__/upload.test.ts
@@ -395,7 +395,7 @@ describe('upload - メタデータ更新ロジックテスト', () => {
           distDir: 'dist',
           title: undefined as string | undefined,
           description: undefined as string | undefined,
-          outputBufferType: 'UnsignedByteType' as const,
+          outputBufferType: 'FloatType' as const,
         },
       };
 
@@ -415,7 +415,7 @@ describe('upload - メタデータ更新ロジックテスト', () => {
       }
 
       expect(updateRequest).toEqual({
-        outputBufferType: 'UnsignedByteType',
+        outputBufferType: 'FloatType',
       });
     });
 

--- a/src/lib/__tests__/upload.test.ts
+++ b/src/lib/__tests__/upload.test.ts
@@ -363,6 +363,62 @@ describe('upload - メタデータ更新ロジックテスト', () => {
       });
     });
 
+    it('outputBufferTypeが設定されている場合、更新リクエストに含まれる', () => {
+      const config = {
+        world: {
+          distDir: 'dist',
+          title: 'Test World',
+          outputBufferType: 'HalfFloatType' as const,
+        },
+      };
+
+      const updateRequest: {
+        name?: string;
+        outputBufferType?: string;
+      } = {};
+      if (config.world.title) {
+        updateRequest.name = config.world.title;
+      }
+      if (config.world.outputBufferType) {
+        updateRequest.outputBufferType = config.world.outputBufferType;
+      }
+
+      expect(updateRequest).toEqual({
+        name: 'Test World',
+        outputBufferType: 'HalfFloatType',
+      });
+    });
+
+    it('outputBufferTypeのみが設定されている場合、outputBufferTypeのみを含む更新リクエストが作成される', () => {
+      const config = {
+        world: {
+          distDir: 'dist',
+          title: undefined as string | undefined,
+          description: undefined as string | undefined,
+          outputBufferType: 'FloatType' as const,
+        },
+      };
+
+      const updateRequest: {
+        name?: string;
+        description?: string;
+        outputBufferType?: string;
+      } = {};
+      if (config.world.title) {
+        updateRequest.name = config.world.title;
+      }
+      if (config.world.description !== undefined) {
+        updateRequest.description = config.world.description;
+      }
+      if (config.world.outputBufferType) {
+        updateRequest.outputBufferType = config.world.outputBufferType;
+      }
+
+      expect(updateRequest).toEqual({
+        outputBufferType: 'FloatType',
+      });
+    });
+
     it('physicsがallowInfiniteJumpのみの場合も正しく更新リクエストに含まれる', () => {
       const config = {
         world: {

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -217,6 +217,7 @@ export async function uploadWorld(cwd: string = process.cwd(), skipCheck?: boole
         physics: worldConfig.physics,
         camera: worldConfig.camera,
         permissions: worldConfig.permissions,
+        outputBufferType: worldConfig.outputBufferType,
         contentHash,
         fileSize,
         files: uploadFiles.map((f) => ({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,7 +22,7 @@ export interface ItemPermissions {
   allowedCodeRules?: string[];
 }
 
-export type OutputBufferType = 'UnsignedByteType' | 'HalfFloatType' | 'FloatType';
+export type OutputBufferType = 'UnsignedByteType' | 'HalfFloatType';
 
 export interface XriftConfig {
   world?: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,7 +22,7 @@ export interface ItemPermissions {
   allowedCodeRules?: string[];
 }
 
-export type OutputBufferType = 'UnsignedByteType' | 'HalfFloatType';
+export type OutputBufferType = 'UnsignedByteType' | 'HalfFloatType' | 'FloatType';
 
 export interface XriftConfig {
   world?: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,8 @@ export interface ItemPermissions {
   allowedCodeRules?: string[];
 }
 
+export type OutputBufferType = 'UnsignedByteType' | 'HalfFloatType' | 'FloatType';
+
 export interface XriftConfig {
   world?: {
     distDir: string;
@@ -33,6 +35,7 @@ export interface XriftConfig {
     physics?: PhysicsConfig; // 物理設定
     camera?: CameraConfig; // カメラ設定
     permissions?: WorldPermissions; // セキュリティ権限宣言
+    outputBufferType?: OutputBufferType; // WebGLRenderer の出力バッファタイプ
   };
   item?: {
     distDir: string; // ビルド成果物のディレクトリ
@@ -93,6 +96,7 @@ export interface UploadUrlsRequest {
   physics?: PhysicsConfig; // 物理設定（任意）
   camera?: CameraConfig; // カメラ設定（任意）
   permissions?: WorldPermissions; // セキュリティ権限宣言（任意）
+  outputBufferType?: OutputBufferType; // WebGLRenderer の出力バッファタイプ（任意）
   contentHash: string;
   fileSize: number;
   files: Array<{


### PR DESCRIPTION
## Summary
- xrift.json の `world` 設定に `outputBufferType` フィールドを追加
- Three.js `WebGLRenderer` の出力バッファタイプ（`UnsignedByteType` / `HalfFloatType` / `FloatType`）を指定可能に
- ワールドアップロード時にバックエンドへ `outputBufferType` を送信

## Test plan
- [x] `outputBufferType` を含む xrift.json の読み込みテスト
- [x] `outputBufferType` 未指定時の undefined テスト
- [x] アップロードリクエストへの `outputBufferType` 含有テスト
- [x] 全テスト通過確認
- [x] TypeScript 型チェック通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)