### PR TITLE
fix: no-unauthorized-domain ルールでもヒント文を表示する

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/cli",
-  "version": "0.24.0",
+  "version": "0.24.2",
   "description": "XRift CLI tool for world and avatar uploads",
   "type": "module",
   "main": "dist/index.js",

--- a/src/lib/check.ts
+++ b/src/lib/check.ts
@@ -343,7 +343,8 @@ export function printResults(checkResult: SecurityCheckResult, projectType: 'wor
       }
     }
 
-    const allowableViolations = [...violatedRules].filter((r) => (ALLOWABLE_RULES as readonly string[]).includes(r));
+    const domainRules = ['no-network-without-permission', 'no-unauthorized-domain'];
+    const allowableViolations = [...violatedRules].filter((r) => (ALLOWABLE_RULES as readonly string[]).includes(r) || domainRules.includes(r));
     const neverAllowableViolations = [...violatedRules].filter((r) => (NEVER_ALLOWABLE_RULES as readonly string[]).includes(r));
 
     if (allowableViolations.length > 0 || neverAllowableViolations.length > 0) {
@@ -352,7 +353,7 @@ export function printResults(checkResult: SecurityCheckResult, projectType: 'wor
       const allowedCodeRulesExample: string[] = [];
 
       for (const rule of allowableViolations) {
-        if (rule === 'no-network-without-permission') {
+        if (domainRules.includes(rule)) {
           console.log(chalk.cyan(`  - "${rule}" → Add target domains to allowedDomains`));
         } else {
           console.log(chalk.cyan(`  - "${rule}" → Add to allowedCodeRules to allow`));
@@ -370,7 +371,7 @@ export function printResults(checkResult: SecurityCheckResult, projectType: 'wor
         if (allowedCodeRulesExample.length > 0) {
           examplePermissions.allowedCodeRules = allowedCodeRulesExample;
         }
-        if (allowableViolations.includes('no-network-without-permission')) {
+        if (allowableViolations.some((r) => domainRules.includes(r))) {
           examplePermissions.allowedDomains = ['api.example.com'];
         }
 


### PR DESCRIPTION
## Summary
- `no-unauthorized-domain` が `ALLOWABLE_RULES` / `NEVER_ALLOWABLE_RULES` のどちらにも含まれないため、ヒント文が表示されなかった
- ドメイン系ルール (`no-network-without-permission`, `no-unauthorized-domain`) をまとめて扱い、`allowedDomains` で解決可能な旨のヒントを出すよう修正
- バージョンを 0.24.2 に更新

## Test plan
- [x] `npm run build` でビルド成功
- [x] `npm test` で全61テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)